### PR TITLE
use k8s command executor instead of ecs command executor

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
@@ -6,6 +6,8 @@ import com.google.inject.Scopes;
 import io.digdag.spi.CommandExecutor;
 import io.digdag.standards.command.ecs.DefaultEcsClientFactory;
 import io.digdag.standards.command.ecs.EcsClientFactory;
+import io.digdag.standards.command.kubernetes.DefaultKubernetesClientFactory;
+import io.digdag.standards.command.kubernetes.KubernetesClientFactory;
 
 public class CommandExecutorModule
     implements Module
@@ -13,10 +15,10 @@ public class CommandExecutorModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(CommandExecutor.class).to(EcsCommandExecutor.class).in(Scopes.SINGLETON);
-        binder.bind(EcsClientFactory.class).to(DefaultEcsClientFactory.class).in(Scopes.SINGLETON);
-        //binder.bind(CommandExecutor.class).to(KubernetesCommandExecutor.class).in(Scopes.SINGLETON);
-        //binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
+        //binder.bind(CommandExecutor.class).to(EcsCommandExecutor.class).in(Scopes.SINGLETON);
+        //binder.bind(EcsClientFactory.class).to(DefaultEcsClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(CommandExecutor.class).to(KubernetesCommandExecutor.class).in(Scopes.SINGLETON);
+        binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
         binder.bind(DockerCommandExecutor.class).in(Scopes.SINGLETON);
     }


### PR DESCRIPTION
use kubernetes command executor instead of ecs command executor
guice直すコストより書き換える方が早いので、書き換えます