### PR TITLE
update k8s client version in v0.10.4_pathced branch to 5.12.1 

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     }
 
     // kubernetes
-    compile ('io.fabric8:kubernetes-client:4.6.2') {
+    compile ('io.fabric8:kubernetes-client:5.12.1') {
         // Avoid compilation failures due to dependencies
         exclude group: 'org.slf4j', module: 'slf4j-api'
         // TODO: digdag use version 3.12.0, upgrade to version 3.12.6.

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -10,6 +10,7 @@ import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandRequest;
 import io.digdag.spi.TaskRequest;
 import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -23,8 +24,10 @@ import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.PersistentVolume;
+import io.fabric8.kubernetes.api.model.PersistentVolumeBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeSpec;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimSpec;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -182,13 +185,15 @@ public class DefaultKubernetesClient
         final Config kubernetesPvConfig = extractTargetKindConfig(context, "PersistentVolume");
         if (kubernetesPvConfig != null && kubernetesPvConfig.has("spec"))
             return client.persistentVolumes()
-                .createOrReplaceWithNew()
-                .withNewMetadata()
-                .withName(kubernetesPvConfig.get("name", String.class))
-                .withNamespace(client.getNamespace())
-                .endMetadata()
-                .withSpec(getPersistentVolume(kubernetesPvConfig.get("spec", Config.class)))
-                .done();
+                .createOrReplace(
+                    new PersistentVolumeBuilder()
+                        .withNewMetadata()
+                        .withName(kubernetesPvConfig.get("name", String.class))
+                        .withNamespace(client.getNamespace())
+                        .endMetadata()
+                        .withSpec(getPersistentVolume(kubernetesPvConfig.get("spec", Config.class)))
+                        .build()
+                );
         else
             return null;
     }
@@ -198,13 +203,16 @@ public class DefaultKubernetesClient
         final Config kubernetesPvcConfig = extractTargetKindConfig(context, "PersistentVolumeClaim");
         if (kubernetesPvcConfig != null && kubernetesPvcConfig.has("spec"))
             return client.persistentVolumeClaims()
-                .createOrReplaceWithNew()
-                .withNewMetadata()
-                .withName(kubernetesPvcConfig.get("name", String.class))
-                .withNamespace(client.getNamespace())
-                .endMetadata()
-                .withSpec(getPersistentVolumeClaim(kubernetesPvcConfig.get("spec", Config.class)))
-                .done();
+                .createOrReplace(
+                    new PersistentVolumeClaimBuilder()
+                        .withNewMetadata()
+                        .withName(kubernetesPvcConfig.get("name", String.class))
+                        .withNamespace(client.getNamespace())
+                        .endMetadata()
+                        .withSpec(getPersistentVolumeClaim(kubernetesPvcConfig.get("spec", Config.class)))
+                        .build()
+
+                );
         else
             return null;
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -68,15 +69,16 @@ public class DefaultKubernetesClient
         final Config kubernetesPodConfig = extractTargetKindConfig(context, "Pod");
         final Container container = createContainer(context, request, kubernetesPodConfig, name, commands, arguments);
         final PodSpec podSpec = createPodSpec(context, request, kubernetesPodConfig, container);
-        io.fabric8.kubernetes.api.model.Pod pod = client.pods()
-                .createNew()
-                .withNewMetadata()
-                .withName(name)
-                .withNamespace(client.getNamespace())
-                .withLabels(getPodLabels())
-                .endMetadata()
-                .withSpec(podSpec)
-                .done();
+        final io.fabric8.kubernetes.api.model.Pod pod = client.pods().inNamespace(client.getNamespace()).create(
+               new PodBuilder()
+                   .withNewMetadata()
+                   .withName(name)
+                   .withLabels(getPodLabels())
+                   .withNamespace(client.getNamespace())
+                   .endMetadata()
+                   .withSpec(podSpec)
+                   .build()
+               );
         return Pod.of(pod);
     }
 


### PR DESCRIPTION
https://github.com/st-tech/digdag/tree/v0.10.4_patched のkubernetes-clientのバージョンを5.12.1に上げた

[本家へのPR](https://github.com/treasure-data/digdag/pull/1722)

マージされたらRelease作成