### PR TITLE
fix handling at graal evaludate error context closed

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -131,11 +131,12 @@ public class GraalJsEngine
             }
             catch (IllegalStateException e) {
                 /**
-                 *  When shutdown sequence started, engine is closed before call and tasks will fail.
+                 *  When shutdown sequence started, engine or context is closed before call and tasks will fail.
                  *  To avoid it, create new engine and retry.
                  */
-                if (e.getMessage().equals("Engine is already closed.")) {
-                    logger.debug("Engine is already closed. Retry with new engine");
+                String message = e.getMessage();
+                if ("Engine is already closed.".equals(message) || "The Context is already closed.".equals(message)) {
+                    logger.warn("Retry with new engine. Because: {}", message);
                     return new GraalEvaluator(createContextSupplier(Optional.empty(), params, libraryJsSources)
                             , extendedSyntax).evaluate(code, scopedParams, jsonMapper);
                 }


### PR DESCRIPTION
コンテキストがクローズしていたときもretryするようにしました。

```
java.lang.RuntimeException: Failed to process variables
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:246)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:75)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:132)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.oracle.truffle.polyglot.PolyglotIllegalStateException: The Context is already closed.
	at com.oracle.truffle.polyglot.PolyglotContextImpl.checkClosed(PolyglotContextImpl.java:713)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.enterThreadChanged(PolyglotContextImpl.java:456)
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enter(PolyglotEngineImpl.java:1531)
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enterIfNeeded(PolyglotEngineImpl.java:1507)
	at com.oracle.truffle.polyglot.PolyglotLanguageContext.getHostBindings(PolyglotLanguageContext.java:293)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.getBindings(PolyglotContextImpl.java:675)
	at org.graalvm.polyglot.Context.getBindings(Context.java:407)
	at io.digdag.core.agent.GraalJsEngine$GraalEvaluator.evaluate(GraalJsEngine.java:175)
	at io.digdag.core.agent.GraalJsEngine$GraalEvaluatorWithRetry.evaluate(GraalJsEngine.java:130)
	at io.digdag.core.agent.ConfigEvalEngine$Context.evalValue(ConfigEvalEngine.java:239)
	at io.digdag.core.agent.ConfigEvalEngine$Context.evalObjectRecursive(ConfigEvalEngine.java:195)
	at io.digdag.core.agent.ConfigEvalEngine$Context.access$300(ConfigEvalEngine.java:164)
	at io.digdag.core.agent.ConfigEvalEngine.eval(ConfigEvalEngine.java:321)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.evalConfig(OperatorManager.java:226)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:240)
	... 16 common frames omitted
```

jsの評価を行っているところなので、ここでretryを行っても実際のタスクには影響ないと判断。

```
+step1:
  if>: ${xxxx} <--ここの評価で利用しているため
  sh>: echo "ほげ"
```
上位でfor文とか使っている場合に影響あるかと検討したが、Contextは毎回生成しなおしているので、問題ない認識  
  
