### PR TITLE
アラート対応：GraalJSエラー時にリトライ（Multi threaded access requested〜）

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -135,7 +135,7 @@ public class GraalJsEngine
                  *  To avoid it, create new engine and retry.
                  */
                 String message = e.getMessage();
-                if ("Engine is already closed.".equals(message) || "The Context is already closed.".equals(message)) {
+                if ("Engine is already closed.".equals(message) || "The Context is already closed.".equals(message) || message.matches("^Multi threaded access requested.*")) {
                     logger.warn("Retry with new engine. Because: {}", message);
                     return new GraalEvaluator(createContextSupplier(Optional.empty(), params, libraryJsSources)
                             , extendedSyntax).evaluate(code, scopedParams, jsonMapper);

--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -135,7 +135,7 @@ public class GraalJsEngine
                  *  To avoid it, create new engine and retry.
                  */
                 String message = e.getMessage();
-                if ("Engine is already closed.".equals(message) || "The Context is already closed.".equals(message) || message.matches("^Multi threaded access requested.*")) {
+                if ("Engine is already closed.".equals(message) || "The Context is already closed.".equals(message) || message.startsWith("Multi threaded access requested")) {
                     logger.warn("Retry with new engine. Because: {}", message);
                     return new GraalEvaluator(createContextSupplier(Optional.empty(), params, libraryJsSources)
                             , extendedSyntax).evaluate(code, scopedParams, jsonMapper);


### PR DESCRIPTION
## 概要
GraalJSのエラーで以下のメッセージに一致する場合リトライを実行
```
Multi threaded access requested
```
### 参考：エラー発生時のログ
https://ma-digdag.zozo-inc.com/sessions/1234795
`Caused by: com.oracle.truffle.polyglot.PolyglotIllegalStateException: Multi threaded access requested by thread Thread[0057@[0:zozo-notification:1234795:1236957]+delivery_workflow_starter+start_workflows^sub+get_waiting_request_ids,5,main] but is not allowed for language(s) js.`と出力されている

```
2025-10-13 23:36:17.259 +0000 [ERROR] (0057@[0:zozo-notification:1234795:1236957]+delivery_workflow_starter+start_workflows^sub+get_waiting_request_ids) io.digdag.core.agent.OperatorManager: Task failed with unexpected error: Failed to process variables
java.lang.RuntimeException: Failed to process variables
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:246)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:75)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:132)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.oracle.truffle.polyglot.PolyglotIllegalStateException: Multi threaded access requested by thread Thread[0057@[0:zozo-notification:1234795:1236957]+delivery_workflow_starter+start_workflows^sub+get_waiting_request_ids,5,main] but is not allowed for language(s) js.
	at com.oracle.truffle.polyglot.PolyglotContextImpl.throwDeniedThreadAccess(PolyglotContextImpl.java:638)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.checkAllThreadAccesses(PolyglotContextImpl.java:541)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.enterThreadChanged(PolyglotContextImpl.java:468)
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enter(PolyglotEngineImpl.java:1531)
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enterIfNeeded(PolyglotEngineImpl.java:1507)
	at com.oracle.truffle.polyglot.PolyglotLanguageContext.getHostBindings(PolyglotLanguageContext.java:293)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.getBindings(PolyglotContextImpl.java:675)
	at org.graalvm.polyglot.Context.getBindings(Context.java:407)
	at io.digdag.core.agent.GraalJsEngine$GraalEvaluator.evaluate(GraalJsEngine.java:176)
	at io.digdag.core.agent.GraalJsEngine$GraalEvaluatorWithRetry.evaluate(GraalJsEngine.java:130)
	at io.digdag.core.agent.ConfigEvalEngine$Context.evalValue(ConfigEvalEngine.java:239)
	at io.digdag.core.agent.ConfigEvalEngine$Context.evalObjectRecursive(ConfigEvalEngine.java:195)
	at io.digdag.core.agent.ConfigEvalEngine$Context.access$300(ConfigEvalEngine.java:164)
	at io.digdag.core.agent.ConfigEvalEngine.eval(ConfigEvalEngine.java:321)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.evalConfig(OperatorManager.java:226)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:240)
	... 16 common frames omitted
```
## 動作確認
- [x] ビルドが通ることを確認
  - 参考：https://qiita.com/sonots/items/626b5d08b5876a9c3e35
  - 指定したdocker image：https://github.com/st-tech/digdag/blob/61f385374ed97ad58cbc5e8a33d9f0d5e1211900/.circleci/config.yml#L87
  - ビルド結果
    ```
    Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
    Use '--warning-mode all' to show the individual deprecation warnings.
    See https://docs.gradle.org/6.9.2/userguide/command_line_interface.html#sec:command_line_warnings
    
    BUILD SUCCESSFUL in 1m 9s
    37 actionable tasks: 2 executed, 35 up-to-date
    ```
    <img width="195" height="58" alt="スクリーンショット 2025-10-28 11 54 58" src="https://github.com/user-attachments/assets/3addb7bc-b606-4975-a83e-9256a2b828c0" />
- [ ] マージ後にStaging環境で`delivery_workflow_starter`を実行し正常終了することを確認

## リリース後の対応
タグ`v0.10.5_patched_3`作成
buildした成果物のjarを添付
https://github.com/st-tech/ma-gcp-infra/blob/main/docker/digdag/Dockerfile#L15
imageのhashを書き換えてリリースで完了
ref: https://github.com/st-tech/ma-gcp-infra/pull/1373