### PR TITLE
[WIP]Upgrade Google auth and cloud libraries to fix intermittent auth errors(ベースブランチを作り直す)

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -54,13 +54,13 @@ dependencies {
     // dependency conflict resolution
     compile 'joda-time:joda-time:2.9.4'
 
-    compile ('com.google.auth:google-auth-library-credentials:0.18.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.auth:google-auth-library-oauth2-http:0.18.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.http-client:google-http-client:1.24.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.http-client:google-http-client-jackson2:1.24.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.oauth-client:google-oauth-client:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.auth:google-auth-library-credentials:1.23.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.auth:google-auth-library-oauth2-http:1.23.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client:1.44.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client-jackson2:1.44.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.oauth-client:google-oauth-client:1.35.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
-    compile ('com.google.cloud:google-cloud-core:1.94.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.cloud:google-cloud-core:1.96.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
     compile 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/digdag-storage-gcs/build.gradle
+++ b/digdag-storage-gcs/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':digdag-plugin-utils')
     testCompile project(':digdag-core')
 
-    compile ("com.google.cloud:google-cloud-storage:1.101.0") {
+    compile ("com.google.cloud:google-cloud-storage:1.118.1") {
         // Avoid compilation failures due to dependencies
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
@@ -18,8 +18,8 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
 
-    compile ('com.google.auth:google-auth-library-oauth2-http:0.18.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ("com.google.cloud:google-cloud-nio:0.119.0-alpha") {
+    compile ('com.google.auth:google-auth-library-oauth2-http:1.23.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ("com.google.cloud:google-cloud-nio:0.124.8") {
         // Avoid compilation failures due to dependencies
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'


### PR DESCRIPTION
Update dependency versions to address "Anonymous caller" authentication errors that occur intermittently when accessing GCS.

Changes:
- google-auth-library-credentials: 0.18.0 -> 1.23.0
- google-auth-library-oauth2-http: 0.18.0 -> 1.23.0
- google-http-client: 1.24.1 -> 1.44.1
- google-http-client-jackson2: 1.24.1 -> 1.44.1
- google-oauth-client: 1.22.0 -> 1.35.0
- google-cloud-core: 1.94.0 -> 1.96.0
- google-cloud-storage: 1.101.0 -> 1.118.1
- google-cloud-nio: 0.119.0-alpha -> 0.124.8

The old google-auth-library (0.18.0 from 2019) had known issues with token refresh in multi-threaded environments, which could cause authentication to fail sporadically.